### PR TITLE
feat: implement verifyToken and authenticateRequest JWKS helpers

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,3 +32,15 @@ php:
   namespace: Clerk\Backend
   outputModelSuffix: output
   packageName: clerk/backend-php
+  additionalDependencies: {
+    "autoload": {},
+    "autoload-dev": {
+      "Clerk\\Backend\\Tests\\": "Tests/"
+    },
+    "require": {
+      "firebase/php-jwt": "^6.10",
+      "phpseclib/phpseclib": "^3.0"
+    },
+    "require-dev": {}
+    }
+  }

--- a/README.md
+++ b/README.md
@@ -28,15 +28,44 @@
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk-backend-php) is the easiest way to add authentication and user management to your application. To gain a better understanding of the Clerk Backend API, refer to the <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
-## Getting started
+<!-- Start Summary [summary] -->
+## Summary
 
-### Prerequisites
+Clerk Backend API: The Clerk REST Backend API, meant to be accessed by backend
+servers.
 
-## Installation
+### Versions
 
-```sh
-composer require clerk/backend-php
+When the API changes in a way that isn't compatible with older versions, a new version is released.
+Each version is identified by its release date, e.g. `2021-02-05`. For more information, please see [Clerk API Versions](https://clerk.com/docs/backend-requests/versioning/overview).
+
+
+Please see https://clerk.com/docs for more information.
+
+More information about the API can be found at https://clerk.com/docs
+<!-- End Summary [summary] -->
+
+<!-- Start Table of Contents [toc] -->
+## Table of Contents
+
+* [SDK Installation](#sdk-installation)
+* [Usage](#usage)
+* [SDK Example Usage](#sdk-example-usage)
+* [Available Resources and Operations](#available-resources-and-operations)
+* [Error Handling](#error-handling)
+* [Server Selection](#server-selection)
+<!-- End Table of Contents [toc] -->
+
+<!-- Start SDK Installation [installation] -->
+## SDK Installation
+
+The SDK relies on [Composer](https://getcomposer.org/) to manage its dependencies.
+
+To install the SDK and add it as a dependency to an existing `composer.json` file:
+```bash
+composer require "clerk/backend-php"
 ```
+<!-- End SDK Installation [installation] -->
 
 ## Usage
 
@@ -47,6 +76,33 @@ CLERK_PUBLISHABLE_KEY=pk_*******
 CLERK_SECRET_KEY=sk_******
 ```
 
+<!-- Start SDK Example Usage [usage] -->
+## SDK Example Usage
+
+### Example
+
+```php
+declare(strict_types=1);
+
+require 'vendor/autoload.php';
+
+use Clerk\Backend;
+
+$security = '<YOUR_BEARER_TOKEN_HERE>';
+
+$sdk = Backend\ClerkBackend::builder()->setSecurity($security)->build();
+
+
+
+$response = $sdk->emailAddresses->get(
+    emailAddressId: '<id>'
+);
+
+if ($response->emailAddress !== null) {
+    // handle response
+}
+```
+<!-- End SDK Example Usage [usage] -->
 
 <!-- Start Available Resources and Operations [operations] -->
 ## Available Resources and Operations
@@ -356,71 +412,6 @@ You can override the default server globally by passing a server index to the `s
 The default server can also be overridden globally by passing a URL to the `server_url: str` optional parameter when initializing the SDK client instance. For example:
 <!-- End Server Selection [server] -->
 
-<!-- Start Summary [summary] -->
-## Summary
-
-Clerk Backend API: The Clerk REST Backend API, meant to be accessed by backend
-servers.
-
-### Versions
-
-When the API changes in a way that isn't compatible with older versions, a new version is released.
-Each version is identified by its release date, e.g. `2021-02-05`. For more information, please see [Clerk API Versions](https://clerk.com/docs/backend-requests/versioning/overview).
-
-
-Please see https://clerk.com/docs for more information.
-
-More information about the API can be found at https://clerk.com/docs
-<!-- End Summary [summary] -->
-
-<!-- Start Table of Contents [toc] -->
-## Table of Contents
-
-* [SDK Installation](#sdk-installation)
-* [SDK Example Usage](#sdk-example-usage)
-* [Available Resources and Operations](#available-resources-and-operations)
-* [Error Handling](#error-handling)
-* [Server Selection](#server-selection)
-<!-- End Table of Contents [toc] -->
-
-<!-- Start SDK Installation [installation] -->
-## SDK Installation
-
-The SDK relies on [Composer](https://getcomposer.org/) to manage its dependencies.
-
-To install the SDK and add it as a dependency to an existing `composer.json` file:
-```bash
-composer require "clerk/backend-php"
-```
-<!-- End SDK Installation [installation] -->
-
-<!-- Start SDK Example Usage [usage] -->
-## SDK Example Usage
-
-### Example
-
-```php
-declare(strict_types=1);
-
-require 'vendor/autoload.php';
-
-use Clerk\Backend;
-
-$security = '<YOUR_BEARER_TOKEN_HERE>';
-
-$sdk = Backend\ClerkBackend::builder()->setSecurity($security)->build();
-
-
-
-$response = $sdk->emailAddresses->get(
-    emailAddressId: '<id>'
-);
-
-if ($response->emailAddress !== null) {
-    // handle response
-}
-```
-<!-- End SDK Example Usage [usage] -->
 
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ More information about the API can be found at https://clerk.com/docs
 * [SDK Installation](#sdk-installation)
 * [Usage](#usage)
 * [SDK Example Usage](#sdk-example-usage)
+* [Request Authentication](#request-authentication)
 * [Available Resources and Operations](#available-resources-and-operations)
 * [Error Handling](#error-handling)
 * [Server Selection](#server-selection)
@@ -103,6 +104,35 @@ if ($response->emailAddress !== null) {
 }
 ```
 <!-- End SDK Example Usage [usage] -->
+
+## Request Authentication
+
+Use the [authenticateRequest](https://github.com/clerk/clerk-sdk-php/tree/main/src/Helpers/Jwks/AuthenticateRequest.php) method to authenticate a request from your app's frontend (when using a Clerk frontend SDK) to Clerk's Backend API. For example the following utility function checks if the user is effectively signed in:
+
+```php
+use GuzzleHttp\Psr7\Request;
+use Clerk\Backend\Helpers\Jwks\AuthenticateRequestOptions;
+use Clerk\Backend\Helpers\Jwks\AuthenticateRequest;
+use Clerk\Backend\Helpers\Jwks\RequestState;
+
+class UserAuthentication
+{
+    public static function isSignedIn(Request $request): bool
+    {
+        $options = new AuthenticateRequestOptions(
+            secretKey: getenv("CLERK_SECRET_KEY"),
+            authorizedParties: ["https://example.com"]
+        );
+
+        $requestState = AuthenticateRequest::authenticateRequest($request, $options);
+
+        return $requestState.isSignedIn();
+    }
+}
+```
+
+If the request is correctly authenticated, the token's payload is made available in `$requestState->payload`. Otherwise the reason for the token verification failure is given by `requestState->errorReason`.
+
 
 <!-- Start Available Resources and Operations [operations] -->
 ## Available Resources and Operations

--- a/Tests/Helpers/Jwks/AuthenticateRequestTest.php
+++ b/Tests/Helpers/Jwks/AuthenticateRequestTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clerk\Backend\Tests\Helpers\Jwks;
+
+use Clerk\Backend\Helpers\Jwks\AuthenticateRequest;
+use Clerk\Backend\Helpers\Jwks\AuthenticateRequestException;
+use Clerk\Backend\Helpers\Jwks\AuthenticateRequestOptions;
+use Clerk\Backend\Helpers\Jwks\AuthErrorReason;
+
+
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+
+
+final class AuthenticateRequestTest extends TestCase
+{
+    private JwksHelpersFixture $fixture;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixture = new JwksHelpersFixture();
+    }
+
+    public function test_authenticate_request_no_session_token()
+    {
+        $arOptions = new AuthenticateRequestOptions('sk_test_SecretKey');
+
+        $request = new Request('GET', $this->fixture->requestUrl);
+        $state = AuthenticateRequest::authenticateRequest($request, $arOptions);
+
+        $this->assertTrue($state->isSignedOut());
+        $this->assertEquals(AuthErrorReason::$SESSION_TOKEN_MISSING, $state->getErrorReason());
+        $this->assertNull($state->getToken());
+        $this->assertNull($state->getPayload());
+    }
+
+    public function test_authenticate_request_no_secret_key()
+    {
+        $this->expectException(AuthenticateRequestException::class);
+        $this->expectExceptionMessage('Missing Clerk Secret Key.');
+
+        new AuthenticateRequestOptions();
+    }
+    /**
+     * @requires CLERK_SECRET_KEY
+     * @requires CLERK_SESSION_TOKEN
+     */
+    public function test_authenticate_request_cookie()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_SECRET_KEY', 'CLERK_SESSION_TOKEN']);
+
+        $arOptions = new AuthenticateRequestOptions(
+            secretKey: $this->fixture->secretKey,
+            audiences: $this->fixture->audiences,
+            authorizedParties: [$this->fixture->authorizedParty],
+        );
+
+        $request = new Request('GET', $this->fixture->requestUrl, [
+            'Cookie' => "__session={$this->fixture->sessionToken}",
+        ]);
+
+        $state = AuthenticateRequest::authenticateRequest($request, $arOptions);
+
+        Utils::assertState($this, $state, $this->fixture->sessionToken);
+    }
+
+    /**
+     * @requires CLERK_SECRET_KEY
+     * @requires CLERK_SESSION_TOKEN
+     */
+    public function test_authenticate_request_bearer()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_SECRET_KEY', 'CLERK_SESSION_TOKEN']);
+
+        $arOptions = new AuthenticateRequestOptions(
+            secretKey: $this->fixture->secretKey,
+            audiences: $this->fixture->audiences,
+            authorizedParties: [$this->fixture->authorizedParty]
+        );
+
+        $request = new Request('GET', $this->fixture->requestUrl, [
+            'Authorization' => 'Bearer '.$this->fixture->sessionToken,
+        ]);
+
+        $state = AuthenticateRequest::authenticateRequest($request, $arOptions);
+
+        Utils::assertState($this, $state, $this->fixture->sessionToken);
+    }
+
+    public function test_authenticate_request_local()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_JWT_KEY', 'CLERK_SESSION_TOKEN']);
+
+        $arOptions = new AuthenticateRequestOptions(
+            jwtKey: $this->fixture->jwtKey,
+            audiences: $this->fixture->audiences,
+            authorizedParties: [$this->fixture->authorizedParty],
+        );
+
+        $request = new Request('GET', $this->fixture->requestUrl, [
+            'Authorization' => 'Bearer '.$this->fixture->sessionToken,
+        ]);
+
+        $state = AuthenticateRequest::authenticateRequest($request, $arOptions);
+
+        Utils::assertState($this, $state, $this->fixture->sessionToken);
+    }
+
+}

--- a/Tests/Helpers/Jwks/JwksHelpersFixture.php
+++ b/Tests/Helpers/Jwks/JwksHelpersFixture.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Clerk\Backend\Tests\Helpers\Jwks;
+
+
+
+class JwksHelpersFixture
+{
+    public string $requestUrl = 'http://localhost:3000';
+
+    public ?string $secretKey;
+    public ?string $jwtKey;
+    public string $sessionToken;
+    public ?string $apiUrl;
+    public ?array $audiences;
+    public ?string $authorizedParty;
+
+    public string $testToken;
+    public string $testJwtKey;
+
+    public function __construct()
+    {
+
+        $this->secretKey = getenv('CLERK_SECRET_KEY') ?: null;
+        $this->jwtKey = getenv('CLERK_JWT_KEY') ?: null;
+        $this->apiUrl = getenv('CLERK_API_URL') ?: null;
+        $this->sessionToken = getenv('CLERK_SESSION_TOKEN') ?: '';
+        $this->audiences = null;
+        $this->authorizedParty = $this->requestUrl;
+
+        [$this->testToken, $this->testJwtKey] = Utils::generateTokenKeyPair(
+            'ins_abcdefghijklmnopqrstuvwxyz0',
+            new \DateTimeImmutable('-1 minute'),
+            new \DateTimeImmutable(),
+            new \DateTimeImmutable('+1 minute'),
+            $this->requestUrl,
+            $this->authorizedParty
+        );
+    }
+}

--- a/Tests/Helpers/Jwks/Utils.php
+++ b/Tests/Helpers/Jwks/Utils.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Clerk\Backend\Tests\Helpers\Jwks;
+
+use Clerk\Backend\Helpers\Jwks\RequestState;
+use Clerk\Backend\Helpers\Jwks\TokenVerificationErrorReason;
+use Clerk\Backend\Helpers\Jwks\TokenVerificationException;
+use Clerk\Backend\Helpers\Jwks\VerifyToken;
+
+use Clerk\Backend\Helpers\Jwks\VerifyTokenOptions;
+use DateTimeImmutable;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\JWT;
+use phpseclib3\Crypt\RSA;
+
+
+
+use PHPUnit\Framework\TestCase;
+
+class Utils
+{
+    public static function skipIfEnvVarsNotSet(TestCase $test, array $envVars)
+    {
+        $missingEnvVars = [];
+
+        foreach ($envVars as $envVar) {
+            if (getenv($envVar) === false) {
+                $missingEnvVars[] = $envVar;
+            }
+        }
+
+        if (! empty($missingEnvVars)) {
+            $test->markTestSkipped('Missing environment variable(s): '.implode(', ', $missingEnvVars).'.');
+        }
+    }
+
+    public static function generateTokenKeyPair(
+        ?string $keyId = null,
+        ?DateTimeImmutable $issuedAt = null,
+        ?DateTimeImmutable $notBefore = null,
+        ?DateTimeImmutable $expires = null,
+        ?string $audience = null,
+        ?string $authorizedParty = null
+    ): array {
+        $rsa = RSA::createKey(2048);
+        $privateKey = $rsa->withPadding(RSA::SIGNATURE_PKCS1);
+        $publicKey = $privateKey->getPublicKey();
+
+        $defaultIssuedAt = (new DateTimeImmutable('-1 minute'))->getTimeStamp();
+        // WARNING: The iat claim is only checked if the nbf claim is not present
+        // https://github.com/firebase/php-jwt/blob/main/src/JWT.php#L166
+        $defaultNotBefore = ! $issuedAt ? (new DateTimeImmutable())->getTimeStamp() : null;
+        $defaultExpires = (new DateTimeImmutable('+1 minute'))->getTimeStamp();
+        $defaultKeyId = 'ins_abcdefghijklmnopqrstuvwxyz0';
+
+        // Create JWT payload
+        $payload = [
+            'iss' => 'https://test.com',
+            'aud' => $audience,
+            'iat' => $issuedAt ? $issuedAt->getTimestamp() : $defaultIssuedAt,
+            'nbf' => $notBefore ? $notBefore->getTimestamp() : $defaultNotBefore,
+            'exp' => $expires ? $expires->getTimeStamp() : $defaultExpires,
+            'name' => 'Test',
+        ];
+
+        if ($authorizedParty) {
+            $payload['azp'] = $authorizedParty;
+        }
+
+        // Encode the JWT
+        $jwt = JWT::encode($payload, $privateKey, 'RS256', $keyId ?? $defaultKeyId);
+
+        // Export the public key in PEM format
+        $publicKeyPem = $publicKey->toString('PKCS8');
+
+        return [$jwt, $publicKeyPem];
+    }
+
+    public static function assertPayload(TestCase $test, $sessionToken, VerifyTokenOptions $options): void
+    {
+        $expired = false;
+        $payload = null;
+
+        try {
+            $payload = VerifyToken::verifyToken($sessionToken, $options);
+        } catch (TokenVerificationException $ex) {
+            if ($ex->getReason() !== TokenVerificationErrorReason::$TOKEN_EXPIRED) {
+                throw $ex;
+            }
+            $test->assertInstanceOf(ExpiredException::class, $ex->getPrevious());
+            echo "WARNING: the provided token is expired!\n";
+            $expired = true;
+        }
+
+        if (! $expired) {
+            $test->assertNotNull($payload);
+            $test->assertTrue(isset($payload->iss));
+        }
+    }
+
+    public static function assertState(TestCase $test, RequestState $state, string $token): void
+    {
+        if ($state->isSignedIn()) {
+            $test->assertNull($state->getErrorReason());
+            $test->assertEquals($token, $state->getToken());
+            $test->assertNotNull($state->getPayload());
+        } else {
+            $test->assertEquals(TokenVerificationErrorReason::$TOKEN_EXPIRED, $state->getErrorReason());
+            $test->assertNull($state->getToken());
+            $test->assertNull($state->getPayload());
+            echo "WARNING: the provided token is expired!\n";
+        }
+    }
+
+}

--- a/Tests/Helpers/Jwks/VerifyTokenTest.php
+++ b/Tests/Helpers/Jwks/VerifyTokenTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clerk\Backend\Tests\Helpers\Jwks;
+
+
+use Clerk\Backend\Helpers\Jwks\TokenVerificationErrorReason;
+use Clerk\Backend\Helpers\Jwks\TokenVerificationException;
+use Clerk\Backend\Helpers\Jwks\VerifyToken;
+use Clerk\Backend\Helpers\Jwks\VerifyTokenOptions;
+
+use PHPUnit\Framework\TestCase;
+
+final class VerifyTokenTest extends TestCase
+{
+    private JwksHelpersFixture $fixture;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixture = new JwksHelpersFixture();
+    }
+
+    public function test_verify_token_no_secret_key()
+    {
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$SECRET_KEY_MISSING->getMessage());
+        new VerifyTokenOptions();
+    }
+
+    public function test_verify_token_invalid_secret_key()
+    {
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$JWK_FAILED_TO_LOAD->getMessage());
+
+        $vtOptions = new VerifyTokenOptions(secretKey: 'sk_test_invalid');
+        VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+    }
+
+    public function test_verify_token_invalid_jwt_key()
+    {
+        $vtOptions = new VerifyTokenOptions(jwtKey: 'invalid.jwt.key');
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$JWK_LOCAL_INVALID->getMessage());
+        VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+    }
+
+    public function test_verify_token_invalid_signature()
+    {
+        $vtOptions = new VerifyTokenOptions(
+            jwtKey: str_replace('+', '0', $this->fixture->testJwtKey)  // tampering with the key
+        );
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_INVALID_SIGNATURE->getMessage());
+        VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+    }
+
+    public function test_verify_token_not_active_yet()
+    {
+        [$token, $jwtKey] = Utils::generateTokenKeyPair(
+            notBefore: new \DateTimeImmutable('+10 seconds')
+        );
+
+        $vtOptions = new VerifyTokenOptions(jwtKey: $jwtKey);
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_NOT_ACTIVE_YET->getMessage());
+        VerifyToken::verifyToken($token, $vtOptions);
+    }
+
+    public function test_verify_token_clock_skew()
+    {
+        $nbfDateTime = new \DateTimeImmutable('+10 seconds');
+        $nbfTimeStamp = $nbfDateTime->getTimestamp();
+
+        [$token, $jwtKey] = Utils::generateTokenKeyPair(
+            issuedAt: new \DateTimeImmutable('-1 minute'),
+            notBefore: $nbfDateTime,
+            expires: new \DateTimeImmutable('+2 minutes')
+        );
+
+        $vtOptions = new VerifyTokenOptions(jwtKey: $jwtKey, clockSkewInMs: 0);
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_NOT_ACTIVE_YET->getMessage());
+
+        VerifyToken::verifyToken($token, $vtOptions);
+
+        $vtOptions = new VerifyTokenOptions(jwtKey: $jwtKey, clockSkewInMs: 10000);
+        $payload = VerifyToken::verifyToken($token, $vtOptions);
+        $this->assertTrue(isset($payload->nbf));
+        $this->assertEquals($nbfTimeStamp, $payload->nbf);
+    }
+
+    public function test_verify_token_expired()
+    {
+        [$token, $jwtKey] = Utils::generateTokenKeyPair(
+            issuedAt: new \DateTimeImmutable('-3 minutes'),
+            notBefore: new \DateTimeImmutable('-2 minutes'),
+            expires: new \DateTimeImmutable('-1 minute')
+        );
+
+        $vtOptions = new VerifyTokenOptions(jwtKey: $jwtKey);
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_EXPIRED->getMessage());
+        VerifyToken::verifyToken($token, $vtOptions);
+    }
+
+    public function test_verify_token_issued_in_the_future()
+    {
+        // WARNING: The iat claim is only checked if the nbf claim is not present
+        // https://github.com/firebase/php-jwt/blob/main/src/JWT.php#L166
+
+        $iatClaim = new \DateTimeImmutable('+1 minute');
+        $expClaim = new \DateTimeImmutable('+2 minutes');
+
+        [$token, $jwtKey] = Utils::generateTokenKeyPair(
+            issuedAt: $iatClaim,
+            expires: $expClaim
+        );
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_IAT_IN_THE_FUTURE->getMessage());
+        VerifyToken::verifyToken($token, new VerifyTokenOptions(jwtKey: $jwtKey));
+    }
+
+    public function test_verify_token_invalid_audience()
+    {
+        $vtOptions = new VerifyTokenOptions(
+            jwtKey: $this->fixture->testJwtKey,
+            audiences: [$this->fixture->requestUrl]
+        );
+
+        $payload = VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+
+        $this->assertTrue(isset($payload->aud));
+        $this->assertEquals($this->fixture->requestUrl, $payload->aud);
+
+        $vtOptions = new VerifyTokenOptions(
+            jwtKey: $this->fixture->testJwtKey,
+            audiences: ['invalid.audience']
+        );
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_INVALID_AUDIENCE->getMessage());
+        VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+    }
+
+    public function test_verify_token_invalid_authorized_parties()
+    {
+        $vtOptions = new VerifyTokenOptions(
+            jwtKey: $this->fixture->testJwtKey,
+            authorizedParties: ['http://some.authorized.party', $this->fixture->authorizedParty],
+        );
+        $payload = VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+        $this->assertTrue(isset($payload->azp));
+        $this->assertContains($payload->azp, $vtOptions->getAuthorizedParties());
+
+
+        $vtOptions = new VerifyTokenOptions(
+            jwtKey: $this->fixture->testJwtKey,
+            authorizedParties: ['http://only.authorized.party']
+        );
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_INVALID_AUTHORIZED_PARTIES->getMessage());
+        VerifyToken::verifyToken($this->fixture->testToken, $vtOptions);
+    }
+
+    /**
+     * @requires CLERK_SECRET_KEY
+     */
+    public function test_verify_token_invalid_token()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_SECRET_KEY']);
+
+        $vtOptions = new VerifyTokenOptions(secretKey: $this->fixture->secretKey);
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$TOKEN_INVALID->getMessage());
+        VerifyToken::verifyToken('invalid.session.token', $vtOptions);
+    }
+
+    /**
+     * @requires CLERK_SECRET_KEY
+     */
+    public function test_verify_token_invalid_kid()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_SECRET_KEY']);
+        $token = Utils::generateTokenKeyPair()[0];
+
+        $vtOptions = new VerifyTokenOptions(secretKey: $this->fixture->secretKey);
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage(TokenVerificationErrorReason::$JWK_KID_MISMATCH->getMessage());
+
+        VerifyToken::verifyToken($token, $vtOptions);
+    }
+
+    /**
+     * @requires CLERK_SECRET_KEY
+     * @requires CLERK_SESSION_TOKEN
+     */
+    public function test_verify_token_remote_ok()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_SECRET_KEY', 'CLERK_SESSION_TOKEN']);
+
+        $vtOptions = new VerifyTokenOptions(
+            secretKey: $this->fixture->secretKey,
+            audiences: $this->fixture->audiences,
+            authorizedParties: [$this->fixture->authorizedParty],
+            apiUrl: $this->fixture->apiUrl,
+        );
+
+        Utils::assertPayload($this, $this->fixture->sessionToken, $vtOptions);
+    }
+
+    /**
+     * @requires CLERK_JWT_KEY
+     * @requires CLERK_SESSION_TOKEN
+     */
+    public function test_verify_token_local_ok()
+    {
+        Utils::skipIfEnvVarsNotSet($this, ['CLERK_SECRET_KEY', 'CLERK_SESSION_TOKEN']);
+
+        $vtOptions = new VerifyTokenOptions(
+            jwtKey: $this->fixture->jwtKey,
+            audiences: $this->fixture->audiences,
+            authorizedParties: [$this->fixture->authorizedParty],
+            apiUrl: $this->fixture->apiUrl,
+        );
+
+        Utils::assertPayload($this, $this->fixture->sessionToken, $vtOptions);
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,21 @@
       "Clerk\\Backend\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Clerk\\Backend\\Tests\\": "Tests/"
+    }
+  },
   "license": "MIT",
   "require": {
     "php": "^8.2",
-    "guzzlehttp/guzzle": "^7.0",
-    "speakeasy/serializer": "^4.0.0",
     "brick/date-time": "^0.7.0",
+    "brick/math": "^0.12.1",
+    "firebase/php-jwt": "^6.10",
+    "guzzlehttp/guzzle": "^7.0",
     "phpdocumentor/type-resolver": "^1.8",
-    "brick/math": "^0.12.1"
+    "phpseclib/phpseclib": "^3.0",
+    "speakeasy/serializer": "^4.0.0"
   },
   "require-dev": {
     "laravel/pint": "^1.18.1",

--- a/src/.genignore
+++ b/src/.genignore
@@ -1,0 +1,1 @@
+Helpers/

--- a/src/Helpers/Jwks/AuthErrorReason.php
+++ b/src/Helpers/Jwks/AuthErrorReason.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+/**
+ * The reason for an AuthenticateRequestException being thrown.
+ */
+class AuthErrorReason
+{
+    public static ErrorReason $SESSION_TOKEN_MISSING;
+    public static ErrorReason $SECRET_KEY_MISSING;
+
+    public static function init()
+    {
+        self::$SESSION_TOKEN_MISSING = new ErrorReason(
+            'session-token-missing',
+            'Could not retrieve session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT'
+        );
+        self::$SECRET_KEY_MISSING = new ErrorReason(
+            'secret-key-missing',
+            'Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance.'
+        );
+    }
+}
+
+// Initialize static properties
+AuthErrorReason::init();

--- a/src/Helpers/Jwks/AuthStatus.php
+++ b/src/Helpers/Jwks/AuthStatus.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+/**
+ * The request authentication status.
+ */
+class AuthStatus
+{
+    private static ?AuthStatus $signedIn = null;
+    private static ?AuthStatus $signedOut = null;
+
+    private string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function signedIn(): AuthStatus
+    {
+        if (self::$signedIn === null) {
+            self::$signedIn = new AuthStatus('signed-in');
+        }
+
+        return self::$signedIn;
+    }
+
+    public static function signedOut(): AuthStatus
+    {
+        if (self::$signedOut === null) {
+            self::$signedOut = new AuthStatus('signed-out');
+        }
+
+        return self::$signedOut;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Helpers/Jwks/AuthenticateRequest.php
+++ b/src/Helpers/Jwks/AuthenticateRequest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Helper methods to authenticate requests.
+ */
+class AuthenticateRequest
+{
+    private const SESSION_COOKIE_NAME = '__session';
+
+    /**
+     * Checks if the HTTP request is authenticated.
+     * First the session token is retrieved from either the __session cookie
+     * or the HTTP Authorization header.
+     * Then the session token is verified: networklessly if the options.jwtKey
+     * is provided, otherwise by fetching the JWKS from Clerk's Backend API.
+     *
+     * WARNING: authenticateRequest is applicable in the context of Backend APIs only.
+     *
+     * @param  RequestInterface  $request  The HTTP request to be authenticated.
+     * @param  AuthenticateRequestOptions  $options  The request authentication options.
+     * @return RequestState The request state.
+     *
+     * @throws AuthenticateRequestException If the session token or secret key is missing.
+     */
+    public static function authenticateRequest(
+        RequestInterface $request,
+        AuthenticateRequestOptions $options
+    ): RequestState {
+        $sessionToken = self::getSessionToken($request);
+        if ($sessionToken === null) {
+            return RequestState::signedOut(AuthErrorReason::$SESSION_TOKEN_MISSING);
+        }
+
+        if ($options->getJwtKey() !== null) {
+            $verifyTokenOptions = new VerifyTokenOptions(
+                jwtKey: $options->getJwtKey(),
+                audiences: $options->getAudiences(),
+                authorizedParties: $options->getAuthorizedParties(),
+                clockSkewInMs: $options->getClockSkewInMs()
+            );
+        } elseif ($options->getSecretKey() !== null) {
+            $verifyTokenOptions = new VerifyTokenOptions(
+                secretKey: $options->getSecretKey(),
+                audiences: $options->getAudiences(),
+                authorizedParties: $options->getAuthorizedParties(),
+                clockSkewInMs: $options->getClockSkewInMs()
+            );
+        } else {
+            return RequestState::signedOut(AuthErrorReason::$SECRET_KEY_MISSING);
+        }
+
+        try {
+            $claims = VerifyToken::verifyToken($sessionToken, $verifyTokenOptions);
+
+            return RequestState::signedIn($sessionToken, $claims);
+        } catch (TokenVerificationException $e) {
+            return RequestState::signedOut($e->getReason());
+        }
+    }
+
+    /**
+     * Retrieve token from __session cookie or Authorization header.
+     *
+     * @param  RequestInterface  $request  The HTTP request
+     * @return string|null The session token, if present
+     */
+    private static function getSessionToken(RequestInterface $request): ?string
+    {
+        $authorizationHeaders = $request->getHeader('Authorization');
+        if (! empty($authorizationHeaders)) {
+            $bearerToken = $authorizationHeaders[0];
+            if (! empty($bearerToken)) {
+                return str_replace('Bearer ', '', $bearerToken);
+            }
+        }
+
+        $cookieHeaders = $request->getHeader('Cookie');
+        if (! empty($cookieHeaders)) {
+            $cookieHeaderValue = $cookieHeaders[0];
+            if (! empty($cookieHeaderValue)) {
+                $cookies = array_map('trim', explode(';', $cookieHeaderValue));
+                foreach ($cookies as $cookie) {
+                    [$name, $value] = explode('=', $cookie, 2);
+                    if ($name === self::SESSION_COOKIE_NAME) {
+                        return $value;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Helpers/Jwks/AuthenticateRequestException.php
+++ b/src/Helpers/Jwks/AuthenticateRequestException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+use Exception;
+
+/**
+ * Exception thrown when an error occurs during the authentication process.
+ */
+class AuthenticateRequestException extends Exception
+{
+    private ErrorReason $reason;
+
+    public function __construct(ErrorReason $reason, ?Exception $previous = null)
+    {
+        parent::__construct($reason->getMessage(), 0, $previous);
+        $this->reason = $reason;
+    }
+
+    public function getReason(): ErrorReason
+    {
+        return $this->reason;
+    }
+
+    public function __toString(): string
+    {
+        return $this->reason->getMessage();
+    }
+}

--- a/src/Helpers/Jwks/AuthenticateRequestOptions.php
+++ b/src/Helpers/Jwks/AuthenticateRequestOptions.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+class AuthenticateRequestOptions
+{
+    private const DEFAULT_CLOCK_SKEW_MS = 5000;
+
+    private ?string $secretKey;
+    private ?string $jwtKey;
+    private ?array $audiences;
+    private array $authorizedParties;
+    private int $clockSkewInMs;
+
+    /**
+     * Options to configure AuthenticateRequest::authenticateRequest.
+     *
+     * @param  string|null  $secretKey  The Clerk secret key from the API Keys page in the Clerk Dashboard.
+     * @param  string|null  $jwtKey  PEM Public String used to verify the session token in a networkless manner.
+     * @param  array|null  $audiences  A list of audiences to verify against.
+     * @param  array|null  $authorizedParties  An allowlist of origins to verify against.
+     * @param  int|null  $clockSkewInMs  Allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.
+     * @throws AuthenticateRequestException
+     */
+    public function __construct(
+        ?string $secretKey = null,
+        ?string $jwtKey = null,
+        ?array $audiences = null,
+        ?array $authorizedParties = null,
+        ?int $clockSkewInMs = null
+    ) {
+        if (empty($secretKey) && empty($jwtKey)) {
+            throw new AuthenticateRequestException(AuthErrorReason::$SECRET_KEY_MISSING);
+        }
+
+        $this->secretKey = $secretKey;
+        $this->jwtKey = $jwtKey;
+        $this->audiences = $audiences;
+        $this->authorizedParties = $authorizedParties ?? [];
+        $this->clockSkewInMs = $clockSkewInMs ?? self::DEFAULT_CLOCK_SKEW_MS;
+    }
+
+    public function getSecretKey(): ?string
+    {
+        return $this->secretKey;
+    }
+
+    public function getJwtKey(): ?string
+    {
+        return $this->jwtKey;
+    }
+
+    public function getAudiences(): ?array
+    {
+        return $this->audiences;
+    }
+
+    public function getAuthorizedParties(): array
+    {
+        return $this->authorizedParties;
+    }
+
+    public function getClockSkewInMs(): int
+    {
+        return $this->clockSkewInMs;
+    }
+}

--- a/src/Helpers/Jwks/ErrorReason.php
+++ b/src/Helpers/Jwks/ErrorReason.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+/**
+ * The reason for a TokenVerificationException or AuthenticateRequestException.
+ */
+class ErrorReason
+{
+    private string $id;
+    private string $message;
+
+    public function __construct(string $id, string $message)
+    {
+        $this->id = $id;
+        $this->message = $message;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Helpers/Jwks/RequestState.php
+++ b/src/Helpers/Jwks/RequestState.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+use stdClass;
+
+/**
+ * Authentication State of the request.
+ */
+class RequestState
+{
+    private ?stdClass $payload;
+    private ?ErrorReason $errorReason;
+    private AuthStatus $status;
+    private ?string $token;
+
+    public function __construct(AuthStatus $status, ?ErrorReason $errorReason, ?string $token, ?stdClass $payload)
+    {
+        $this->status = $status;
+        $this->errorReason = $errorReason;
+        $this->token = $token;
+        $this->payload = $payload;
+    }
+
+    public static function signedIn(string $token, stdClass $payload): RequestState
+    {
+        return new RequestState(AuthStatus::signedIn(), null, $token, $payload);
+    }
+
+    public static function signedOut(ErrorReason $errorReason): RequestState
+    {
+        return new RequestState(AuthStatus::signedOut(), $errorReason, null, null);
+    }
+
+    public function isSignedIn(): bool
+    {
+        return $this->status === AuthStatus::signedIn();
+    }
+
+    public function isSignedOut(): bool
+    {
+        return $this->status === AuthStatus::signedOut();
+    }
+
+    public function getPayload(): ?stdClass
+    {
+        return $this->payload;
+    }
+
+    public function getErrorReason(): ?ErrorReason
+    {
+        return $this->errorReason;
+    }
+
+    public function getStatus(): AuthStatus
+    {
+        return $this->status;
+    }
+
+    public function getToken(): ?string
+    {
+        return $this->token;
+    }
+}

--- a/src/Helpers/Jwks/TokenVerificationErrorReason.php
+++ b/src/Helpers/Jwks/TokenVerificationErrorReason.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+/**
+ * The reason for a TokenVerificationException being thrown.
+ */
+class TokenVerificationErrorReason
+{
+    public static ErrorReason $JWK_FAILED_TO_LOAD;
+    public static ErrorReason $JWK_REMOTE_INVALID;
+    public static ErrorReason $JWK_LOCAL_INVALID;
+    public static ErrorReason $JWK_FAILED_TO_RESOLVE;
+    public static ErrorReason $JWK_KID_MISMATCH;
+    public static ErrorReason $TOKEN_EXPIRED;
+    public static ErrorReason $TOKEN_INVALID;
+    public static ErrorReason $TOKEN_INVALID_AUTHORIZED_PARTIES;
+    public static ErrorReason $TOKEN_INVALID_AUDIENCE;
+    public static ErrorReason $TOKEN_IAT_IN_THE_FUTURE;
+    public static ErrorReason $TOKEN_NOT_ACTIVE_YET;
+    public static ErrorReason $TOKEN_INVALID_SIGNATURE;
+    public static ErrorReason $SECRET_KEY_MISSING;
+
+    public static function init()
+    {
+        self::$JWK_FAILED_TO_LOAD = new ErrorReason(
+            'jwk-failed-to-load',
+            'Failed to load JWKS from Clerk Backend API. Contact support@clerk.com.'
+        );
+        self::$JWK_REMOTE_INVALID = new ErrorReason(
+            'jwk-remote-invalid',
+            'The JWKS endpoint did not contain any signing keys. Contact support@clerk.com.'
+        );
+        self::$JWK_LOCAL_INVALID = new ErrorReason(
+            'jwk-local-invalid',
+            'The provided PEM Public Key is not in the proper format.'
+        );
+        self::$JWK_FAILED_TO_RESOLVE = new ErrorReason(
+            'jwk-failed-to-resolve',
+            'Failed to resolve JWK. Public Key is not in the proper format.'
+        );
+        self::$JWK_KID_MISMATCH = new ErrorReason(
+            'jwk-kid-mismatch',
+            'Unable to find a signing key in JWKS that matches the kid of the provided session token.'
+        );
+        self::$TOKEN_EXPIRED = new ErrorReason(
+            'token-expired',
+            'Token has expired and is no longer valid.'
+        );
+        self::$TOKEN_INVALID = new ErrorReason(
+            'token-invalid',
+            'Token is invalid and could not be verified.'
+        );
+        self::$TOKEN_INVALID_AUTHORIZED_PARTIES = new ErrorReason(
+            'token-invalid-authorized-parties',
+            'Authorized party claim (azp) does not match any of the authorized parties.'
+        );
+        self::$TOKEN_INVALID_AUDIENCE = new ErrorReason(
+            'token-invalid-audience',
+            'Token audience claim (aud) does not match one of the expected audience values.'
+        );
+        self::$TOKEN_IAT_IN_THE_FUTURE = new ErrorReason(
+            'token-iat-in-the-future',
+            'Token Issued At claim (iat) represents a time in the future.'
+        );
+        self::$TOKEN_NOT_ACTIVE_YET = new ErrorReason(
+            'token-not-active-yet',
+            'Token is not yet valid. Not Before claim (nbf) is in the future.'
+        );
+        self::$TOKEN_INVALID_SIGNATURE = new ErrorReason(
+            'token-invalid-signature',
+            'Token signature is invalid and could not be verified.'
+        );
+        self::$SECRET_KEY_MISSING = new ErrorReason(
+            'secret-key-missing',
+            'Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance.'
+        );
+    }
+}
+
+// Initialize static properties
+TokenVerificationErrorReason::init();

--- a/src/Helpers/Jwks/TokenVerificationException.php
+++ b/src/Helpers/Jwks/TokenVerificationException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+use Exception;
+
+/**
+ * Exception thrown when an error occurs during the token verification process.
+ */
+class TokenVerificationException extends Exception
+{
+    private ErrorReason $reason;
+
+    public function __construct(ErrorReason $reason, ?Exception $previous = null)
+    {
+        parent::__construct($reason->getMessage(), 0, $previous);
+        $this->reason = $reason;
+    }
+
+    public function getReason(): ErrorReason
+    {
+        return $this->reason;
+    }
+
+    public function __toString(): string
+    {
+        return $this->reason->getMessage();
+    }
+}

--- a/src/Helpers/Jwks/VerifyToken.php
+++ b/src/Helpers/Jwks/VerifyToken.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+use Clerk\Backend\Models\Components\WellKnownJWKS;
+use Clerk\Backend\Utils;
+use Exception;
+use Firebase\JWT\BeforeValidException;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\SignatureInvalidException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
+use Speakeasy\Serializer\DeserializationContext;
+use stdClass;
+
+class VerifyToken
+{
+    /**
+     * Verifies the given JWT token.
+     *
+     * @param  string  $token  The JWT token to verify.
+     * @param  VerifyTokenOptions  $options  The options to use for the verification.
+     * @return stdClass The payload of the verified token.
+     *
+     * @throws TokenVerificationException If the token could not be verified.
+     */
+    public static function verifyToken(string $token, VerifyTokenOptions $options): stdClass
+    {
+        $publicKey = $options->getJwtKey() !== null
+            ? self::getLocalJwtKey($options->getJwtKey())
+            : self::getRemoteJwtKey($token, $options);
+
+        JWT::$leeway = $options->getClockSkewInMs() / 1000;
+
+        try {
+            $payload = JWT::decode($token, new Key($publicKey, 'RS256'));
+        } catch (ExpiredException $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_EXPIRED, $ex);
+        } catch (BeforeValidException $ex) {
+            // either the token is not yet eligle ('nbf' claim) or if it's not been created yet ('iat' claim)
+            $payload = $ex->getPayload();
+
+            if (isset($payload->nbf) && time() < $payload->nbf) {
+                throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_NOT_ACTIVE_YET, $ex);
+            }
+
+            if (isset($payload->iat) && time() < $payload->iat) {
+                throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_IAT_IN_THE_FUTURE, $ex);
+            }
+
+            throw $ex;
+
+        } catch (SignatureInvalidException $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_INVALID_SIGNATURE, $ex);
+        } catch (Exception $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_INVALID, $ex);
+        }
+
+        if ($options->getAudiences() !== null) {
+            if (isset($payload->aud) && ! in_array($payload->aud, $options->getAudiences())) {
+                throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_INVALID_AUDIENCE);
+            }
+        }
+
+        if ($options->getAuthorizedParties() !== null) {
+            if (isset($payload->azp) && ! in_array($payload->azp, $options->getAuthorizedParties())) {
+                throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_INVALID_AUTHORIZED_PARTIES);
+            }
+        }
+
+        return $payload;
+    }
+
+    private static function getLocalJwtKey(string $jwtKey): string
+    {
+        try {
+            $rsaKey = publicKeyLoader::load($jwtKey);
+
+            return $rsaKey->toString('PKCS8');
+        } catch (Exception $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_LOCAL_INVALID, $ex);
+        }
+    }
+
+    private static function getRemoteJwtKey(string $token, VerifyTokenOptions $options): string
+    {
+        $kid = self::parseKid($token);
+
+        $jwks = self::fetchJwks($options);
+        if ($jwks->keys === null) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_REMOTE_INVALID);
+        }
+
+        foreach ($jwks->keys as $key) {
+            if ($key->kid === $kid) {
+                if ($key->n === null || $key->e === null) {
+                    throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_REMOTE_INVALID);
+                }
+                try {
+                    $rsaModulus = JWT::urlsafeB64Decode($key->n);
+                    $rsaExponent = JWT::urlsafeB64Decode($key->e);
+                    $rsaKey = RSA::loadPublicKey([
+                        'n' => new BigInteger($rsaModulus, 256),
+                        'e' => new BigInteger($rsaExponent, 256),
+                    ]);
+
+                    return $rsaKey->toString('PKCS8');
+                } catch (Exception $ex) {
+                    throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_FAILED_TO_RESOLVE, $ex);
+                }
+            }
+        }
+
+        throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_KID_MISMATCH);
+    }
+
+    private static function parseKid(string $token): string
+    {
+        try {
+            $decodedHeader = JWT::jsonDecode(JWT::urlsafeB64Decode(explode('.', $token)[0]));
+            if (isset($decodedHeader->kid)) {
+                return $decodedHeader->kid;
+            }
+        } catch (Exception $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$TOKEN_INVALID, $ex);
+        }
+
+        throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_KID_MISMATCH);
+    }
+
+    private static function fetchJwks(VerifyTokenOptions $options): WellKnownJWKS
+    {
+        if ($options->getSecretKey() === null) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$SECRET_KEY_MISSING);
+        }
+
+        $client = new Client();
+        try {
+            $response = $client->request('GET', "{$options->getApiUrl()}/{$options->getApiVersion()}/jwks", [
+                'headers' => [
+                    'Authorization' => "Bearer {$options->getSecretKey()}",
+                ],
+            ]);
+        } catch (ClientException $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_FAILED_TO_LOAD, $ex);
+        }
+
+        try {
+            $serializer = Utils\JSON::createSerializer();
+            $wellKnownJWKS = $serializer->deserialize((string) $response->getBody(), '\Clerk\Backend\Models\Components\WellKnownJWKS', 'json', DeserializationContext::create()->setRequireAllRequiredProperties(true));
+
+        } catch (Exception $ex) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_FAILED_TO_LOAD, $ex);
+        }
+
+        if ($wellKnownJWKS === null) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$JWK_REMOTE_INVALID);
+        }
+
+        return $wellKnownJWKS;
+    }
+}

--- a/src/Helpers/Jwks/VerifyTokenOptions.php
+++ b/src/Helpers/Jwks/VerifyTokenOptions.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Clerk\Backend\Helpers\Jwks;
+
+class VerifyTokenOptions
+{
+    private const DEFAULT_CLOCK_SKEW_MS = 5000;
+    private const DEFAULT_API_URL = 'https://api.clerk.com';
+    private const DEFAULT_API_VERSION = 'v1';
+
+    private ?string $secretKey;
+    private ?string $jwtKey;
+    private ?array $audiences;
+    private ?array $authorizedParties;
+    private int $clockSkewInMs;
+    private string $apiUrl;
+    private string $apiVersion;
+
+    /**
+     * Options to configure VerifyToken::verifyToken.
+     *
+     * @param  string|null  $secretKey  The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)
+     * @param  string|null  $jwtKey  PEM Public String used to verify the session token in a networkless manner. (Optional)
+     * @param  array|null  $audiences  A list of audiences to verify against.
+     * @param  array|null  $authorizedParties  An allowlist of origins to verify against.
+     * @param  int|null  $clockSkewInMs  Allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.
+     * @param  string|null  $apiUrl  The Clerk Backend API endpoint. Defaults to 'https://api.clerk.com'
+     * @param  string|null  $apiVersion  The version passed to the Clerk API. Defaults to 'v1'
+
+     * @throws TokenVerificationException
+     */
+    public function __construct(
+        ?string $secretKey = null,
+        ?string $jwtKey = null,
+        ?array $audiences = null,
+        ?array $authorizedParties = null,
+        ?int $clockSkewInMs = null,
+        ?string $apiUrl = null,
+        ?string $apiVersion = null
+    ) {
+        if (empty($secretKey) && empty($jwtKey)) {
+            throw new TokenVerificationException(TokenVerificationErrorReason::$SECRET_KEY_MISSING);
+        }
+
+        $this->secretKey = $secretKey;
+        $this->jwtKey = $jwtKey;
+        $this->audiences = $audiences;
+        $this->authorizedParties = $authorizedParties;
+        $this->clockSkewInMs = $clockSkewInMs ?? self::DEFAULT_CLOCK_SKEW_MS;
+        $this->apiUrl = $apiUrl ?? self::DEFAULT_API_URL;
+        $this->apiVersion = $apiVersion ?? self::DEFAULT_API_VERSION;
+    }
+
+    public function getSecretKey(): ?string
+    {
+        return $this->secretKey;
+    }
+
+    public function getJwtKey(): ?string
+    {
+        return $this->jwtKey;
+    }
+
+    public function getAudiences(): ?array
+    {
+        return $this->audiences;
+    }
+
+    public function getAuthorizedParties(): ?array
+    {
+        return $this->authorizedParties;
+    }
+
+    public function getClockSkewInMs(): int
+    {
+        return $this->clockSkewInMs;
+    }
+
+    public function getApiUrl(): string
+    {
+        return $this->apiUrl;
+    }
+
+    public function getApiVersion(): string
+    {
+        return $this->apiVersion;
+    }
+}


### PR DESCRIPTION
**TODO**
-  `additionalDependencies` feature is being implemented so `phpseclib/phpseclib` and `firebase/php-jwt` can be added to the project dependencies using `gen.yaml`
- [PR#3](https://github.com/clerk/clerk-sdk-php/pull/3) should be reviewed/merged beforehand to reduce diffs and ease reviewing this PR.

This PR implements [authenticateRequest](https://clerk.com/docs/references/backend/authenticate-request) and [verifyToken](https://clerk.com/docs/references/backend/verify-token) helper methods.

#### Notes
- the `src/clerk/BackendAPI/Helpers/` folder is *.genignored*
- unlike in the `clerk-sdk-python` implementation, the `secretKey` must be passed manually to the `AuthenticateRequestOptions` and the `bearerAuth` value passed during sdk instantiation cannot be reused for convenience.
(due to [$sdkConfiguration](https://github.com/clerk/clerk-sdk-php/blob/main/src/Jwks.php#L16) being a private member of the `Jwks` SubSDK class).
- unlike in other implementations (Python, C#, Java) the `iat` claim [is only checked when the `nbf` claim is *not* provided](https://github.com/firebase/php-jwt/blob/main/src/JWT.php#L166)

#### Limitations
- the added helper functions are only applicable for Backend APIs, `afterSignInUrl`/`afterSignUpUrl` options are not implemented
- multi-domain setup (`isSatellite`, `proxyUrl`, `signInUrl`, `signUpUrl`) is not implemented
- caching is not covered by this PR and `skipJwksCache` option is not made available

#### Tests
To run all tests (`vendor/bin/pint`) the following environment variables should be set:
- `CLERK_SESSION_TOKEN`: The session token to be tested.
- `CLERK_SECRET_KEY`: The Clerk secret key from the API Keys page in the Clerk Dashboard (needed for fetching Clerk's Jwks)
- `CLERK_JWT_KEY`: The PEM public key from Clerk Dashboard (needed for networkless verification only)

#### Example Usage
1. Remote JWKS (using `secretKey`)
```php
use GuzzleHttp\Psr7\Request;
use Clerk\Backend\Helpers\Jwks\AuthenticateRequestOptions;
use Clerk\Backend\Helpers\Jwks\AuthenticateRequest;
use Clerk\Backend\Helpers\Jwks\RequestState;

class UserAuthentication
{
    public static function isSignedIn(Request $request): bool
    {
        $options = new AuthenticateRequestOptions(
            secretKey: getenv("CLERK_SECRET_KEY"),
            authorizedParties: ["https://example.com"]
        );

        $requestState = AuthenticateRequest::authenticateRequest($request, $options);

        return $requestState.isSignedIn();
    }
}
```

2. Networkless (using local PEM formatted `jwtKey`)
```php
<?php

use GuzzleHttp\Psr7\Request;
use Clerk\Backend\Helpers\Jwks\AuthenticateRequestOptions;
use Clerk\Backend\Helpers\Jwks\AuthenticateRequest;
use Clerk\Backend\Helpers\Jwks\RequestState;

class UserAuthentication
{
    public static function isSignedIn(Request $request): bool
    {
        $options = new AuthenticateRequestOptions(
            jwtKey: getenv('CLERK_JWT_KEY'),
            authorizedParties: ['https://example.com']
        );

        $requestState = AuthenticateRequest::authenticateRequest($request, $options);

        return $requestState->isSignedIn();
    }
}
```